### PR TITLE
ExecuteProcedure Fixed workflows to use master and not main

### DIFF
--- a/.github/workflows/ExecuteProcedure_build_and_test_on_main.yml
+++ b/.github/workflows/ExecuteProcedure_build_and_test_on_main.yml
@@ -3,7 +3,7 @@ name: Frends.Oracle.ExecuteProcedure Main
 on:
   push:
     branches:    
-      - main
+      - master
     paths:
       - 'Frends.Oracle.ExecuteProcedure/**'
   workflow_dispatch:

--- a/.github/workflows/ExecuteProcedure_build_and_test_on_push.yml
+++ b/.github/workflows/ExecuteProcedure_build_and_test_on_push.yml
@@ -3,7 +3,7 @@ name: Frends.Oracle.ExecuteProcedure Test
 on:
   push:
     branches-ignore:    
-      - main
+      - master
     paths:
       - 'Frends.Oracle.ExecuteProcedure/**'
   workflow_dispatch:


### PR DESCRIPTION
#10 
Fixed workflows to use master branch instead of main because the default branch is master. Main workflow was not run because of that. 