### PR TITLE
Add execute type

### DIFF
--- a/Frends.Oracle.ExecuteQuery/CHANGELOG.md
+++ b/Frends.Oracle.ExecuteQuery/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.0.0] - 2025-03-24
+### Added
+- [Breaking] New 'ExecuteType' parameter to control how SQL command string is executed.
+- Default value for new parameter is 'Auto'
+- Use the default parameter if you want the Task to work as before.
+
 ## [2.0.1] - 2022-11-04
 ### Fixed
 - Fixed issue which resulted to task not able to close connection.

--- a/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery.Tests/Lib/Helpers.cs
+++ b/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery.Tests/Lib/Helpers.cs
@@ -100,7 +100,7 @@ end;";
         {
             cmd.ExecuteNonQuery();
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             Console.WriteLine(ex.Message);
             throw;

--- a/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery.Tests/UnitTests.cs
+++ b/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery.Tests/UnitTests.cs
@@ -59,6 +59,7 @@ class TestClass
         _input = new Input
         {
             ConnectionString = _connectionString,
+            ExecuteType = ExecuteTypes.Auto
         };
 
         _options = new Options
@@ -267,6 +268,71 @@ class TestClass
         result = await Oracle.ExecuteQuery(_input, _options, new CancellationToken());
         Assert.AreEqual("Matti", (string)result.Output[0]["FIRST_NAME"]);
         Assert.AreEqual("Meikäläinen", (string)result.Output[0]["LAST_NAME"]);
+    }
+
+    [Test]
+    public async Task ExecuteQuery_NonQueryExecutionType_Explicit()
+    {
+        _input.ExecuteType = ExecuteTypes.NonQuery;
+        _input.Query = "insert into workers (id, first_name, last_name) values (1, 'Matti', 'Meikäläinen')";
+
+        var result = await Oracle.ExecuteQuery(_input, _options, new CancellationToken());
+
+        Assert.That(result, Is.Not.Null);
+        Assert.AreEqual(true, result.Success);
+        Assert.AreEqual(1, (int)result.Output["AffectedRows"]);
+    }
+
+    [Test]
+    public async Task ExecuteQuery_ExecuteReaderExecutionType_Explicit()
+    {
+        _input.ExecuteType = ExecuteTypes.NonQuery;
+        _input.Query = "insert into workers (id, first_name, last_name) values (1, 'Matti', 'Meikäläinen')";
+        await Oracle.ExecuteQuery(_input, _options, new CancellationToken());
+
+        _input.ExecuteType = ExecuteTypes.ExecuteReader;
+        _input.Query = "select first_name from workers where id = 1";
+
+        var result = await Oracle.ExecuteQuery(_input, _options, new CancellationToken());
+
+        Assert.That(result, Is.Not.Null);
+        Assert.AreEqual(true, result.Success);
+        Assert.AreEqual(typeof(JArray), result.Output.GetType());
+        Assert.AreEqual("Matti", (string)result.Output[0]["FIRST_NAME"]);
+    }
+
+    [Test]
+    public async Task ExecuteQuery_ScalarExecutionType_Count()
+    {
+        _input.ExecuteType = ExecuteTypes.NonQuery;
+        _input.Query = "insert into workers (id, first_name, last_name) values (1, 'Matti', 'Meikäläinen')";
+        await Oracle.ExecuteQuery(_input, _options, new CancellationToken());
+
+        _input.ExecuteType = ExecuteTypes.Scalar;
+        _input.Query = "select count(*) from workers";
+
+        var result = await Oracle.ExecuteQuery(_input, _options, new CancellationToken());
+
+        Assert.That(result, Is.Not.Null);
+        Assert.AreEqual(true, result.Success);
+        Assert.AreEqual(1, (int)(decimal)result.Output);
+    }
+
+    [Test]
+    public async Task ExecuteQuery_ScalarExecutionType_SingleValue()
+    {
+        _input.ExecuteType = ExecuteTypes.NonQuery;
+        _input.Query = "insert into workers (id, first_name, last_name) values (1, 'Matti', 'Meikäläinen')";
+        await Oracle.ExecuteQuery(_input, _options, new CancellationToken());
+
+        _input.ExecuteType = ExecuteTypes.Scalar;
+        _input.Query = "select first_name from workers where id = 1";
+
+        var result = await Oracle.ExecuteQuery(_input, _options, new CancellationToken());
+
+        Assert.That(result, Is.Not.Null);
+        Assert.AreEqual(true, result.Success);
+        Assert.AreEqual("Matti", (string)result.Output);
     }
 }
 

--- a/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Definitions/ExecuteTypes.cs
+++ b/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Definitions/ExecuteTypes.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Frends.Oracle.ExecuteQuery.Definitions
+{
+    /// <summary>
+    /// Execute types.
+    /// </summary>
+    public enum ExecuteTypes
+    {
+        /// <summary>
+        /// ExecuteReader for SELECT-query and NonQuery for UPDATE, INSERT, or DELETE statements.
+        /// </summary>
+        Auto,
+
+        /// <summary>
+        /// Executes a Transact-SQL statement against the connection and returns the number of rows affected.
+        /// </summary>
+        NonQuery,
+
+        /// <summary>
+        /// Executes the query, and returns the first column of the first row in the result set returned by the query. Additional columns or rows are ignored.
+        /// </summary>
+        Scalar,
+
+        /// <summary>
+        /// Executes the query, and returns an object that can iterate over the entire result set.
+        /// </summary>
+        ExecuteReader
+    }
+}

--- a/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Definitions/Input.cs
+++ b/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Definitions/Input.cs
@@ -34,5 +34,16 @@ public class Input
     [PasswordPropertyText]
     [DefaultValue("Data Source=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=MyHost)(PORT=MyPort))(CONNECT_DATA=(SERVICE_NAME=MyOracleSID)));User Id=myUsername;Password=myPassword;")]
     public string ConnectionString { get; set; }
+
+    /// <summary>
+    /// Specifies how a command string is interpreted.
+    /// Auto: ExecuteReader for SELECT-query and NonQuery for UPDATE, INSERT, or DELETE statements.
+    /// ExecuteReader: Use this operation to execute any arbitrary SQL statements in SQL Server if you want the result set to be returned.
+    /// NonQuery: Use this operation to execute any arbitrary SQL statements in SQL Server if you do not want any result set to be returned. You can use this operation to create database objects or change data in a database by executing UPDATE, INSERT, or DELETE statements. The return value of this operation is of Int32 data type, and For the UPDATE, INSERT, and DELETE statements, the return value is the number of rows affected by the SQL statement. For all other types of statements, the return value is -1.
+    /// Scalar: Use this operation to execute any arbitrary SQL statements in SQL Server to return a single value. This operation returns the value only in the first column of the first row in the result set returned by the SQL statement.
+    /// </summary>
+    /// <example>ExecuteType.ExecuteReader</example>
+    [DefaultValue(ExecuteTypes.ExecuteReader)]
+    public ExecuteTypes ExecuteType { get; set; }
 }
 

--- a/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Definitions/Input.cs
+++ b/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Definitions/Input.cs
@@ -43,7 +43,7 @@ public class Input
     /// Scalar: Use this operation to execute any arbitrary SQL statements in SQL Server to return a single value. This operation returns the value only in the first column of the first row in the result set returned by the SQL statement.
     /// </summary>
     /// <example>ExecuteType.ExecuteReader</example>
-    [DefaultValue(ExecuteTypes.ExecuteReader)]
+    [DefaultValue(ExecuteTypes.Auto)]
     public ExecuteTypes ExecuteType { get; set; }
 }
 

--- a/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Definitions/Input.cs
+++ b/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Definitions/Input.cs
@@ -38,9 +38,9 @@ public class Input
     /// <summary>
     /// Specifies how a command string is interpreted.
     /// Auto: ExecuteReader for SELECT-query and NonQuery for UPDATE, INSERT, or DELETE statements.
-    /// ExecuteReader: Use this operation to execute any arbitrary SQL statements in SQL Server if you want the result set to be returned.
-    /// NonQuery: Use this operation to execute any arbitrary SQL statements in SQL Server if you do not want any result set to be returned. You can use this operation to create database objects or change data in a database by executing UPDATE, INSERT, or DELETE statements. The return value of this operation is of Int32 data type, and For the UPDATE, INSERT, and DELETE statements, the return value is the number of rows affected by the SQL statement. For all other types of statements, the return value is -1.
-    /// Scalar: Use this operation to execute any arbitrary SQL statements in SQL Server to return a single value. This operation returns the value only in the first column of the first row in the result set returned by the SQL statement.
+    /// ExecuteReader: Use this operation to execute any arbitrary SQL statements in Oracle if you want the result set to be returned.
+    /// NonQuery: Use this operation to execute any arbitrary SQL statements in Oracle if you do not want any result set to be returned. You can use this operation to create database objects or change data in a database by executing UPDATE, INSERT, or DELETE statements. The return value of this operation is of Int32 data type, and For the UPDATE, INSERT, and DELETE statements, the return value is the number of rows affected by the SQL statement. For all other types of statements, the return value is -1.
+    /// Scalar: Use this operation to execute any arbitrary SQL statements in Oracle to return a single value. This operation returns the value only in the first column of the first row in the result set returned by the SQL statement.
     /// </summary>
     /// <example>ExecuteType.ExecuteReader</example>
     [DefaultValue(ExecuteTypes.Auto)]

--- a/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Definitions/Result.cs
+++ b/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Definitions/Result.cs
@@ -4,7 +4,7 @@
 /// Return object with private setters.
 /// </summary>
 public class Result
-{ 
+{
     /// <summary>
     /// Boolean value of success of the query 
     /// </summary>

--- a/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Definitions/TransactionIsolationLevel.cs
+++ b/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Definitions/TransactionIsolationLevel.cs
@@ -7,7 +7,7 @@
 public enum TransactionIsolationLevel
 {
     Default,
-    None, 
+    None,
     ReadUncommitted,
     ReadCommitted,
     RepeatableRead,

--- a/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery.cs
+++ b/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery.cs
@@ -94,8 +94,8 @@ public static class Oracle
             {
                 await con.CloseAsync();
                 con.Dispose();
-            }   
-        } 
+            }
+        }
         catch (Exception ex)
         {
             if (options.ThrowErrorOnFailure)
@@ -113,7 +113,7 @@ public static class Oracle
     {
         return new OracleParameter()
         {
-            ParameterName = parameter.Name, 
+            ParameterName = parameter.Name,
             Value = parameter.Value,
             OracleDbType = (OracleDbType)Enum.Parse(typeof(OracleDbType), parameter.DataType.ToString())
         };
@@ -123,7 +123,7 @@ public static class Oracle
     {
         using var writer = new JTokenWriter();
         writer.Formatting = Formatting.Indented;
-        writer.Culture = CultureInfo.InvariantCulture; 
+        writer.Culture = CultureInfo.InvariantCulture;
 
         writer.WriteStartArray();
 

--- a/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery.csproj
+++ b/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery/Frends.Oracle.ExecuteQuery.csproj
@@ -7,7 +7,7 @@
 	  <AssemblyName>Frends.Oracle.ExecuteQuery</AssemblyName>
 	  <RootNamespace>Frends.Oracle.ExecuteQuery</RootNamespace>
 
-	  <Version>2.0.1</Version>
+	  <Version>3.0.0</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
Added ExecuteType parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new parameter, `ExecuteType`, for SQL command execution, allowing users to specify execution modes: automatic, non-query, scalar, and execute reader.
  
- **Bug Fixes**
  - Enhanced error handling and transaction management during SQL command execution.

- **Chores**
  - Updated the release to version 3.0.0, indicating significant enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->