### PR TITLE
 added retry logic to detect and recover from stale connections

### DIFF
--- a/Frends.Oracle.ExecuteProcedure/CHANGELOG.md
+++ b/Frends.Oracle.ExecuteProcedure/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [2.5.0] - 2026-05-26
 
+### Added
+
+- Added configurable retry mechanism for stale Oracle connections with `ConnectionRetryAttempts` (default: 2, range: 1-5) and `ConnectionRetryDelayMs` (default: 100ms) options.
+
 ### Fixed
 
 - Fixed issue where cached connections would fail after Oracle server restart by adding automatic retry logic to detect and recover from stale connections.

--- a/Frends.Oracle.ExecuteProcedure/CHANGELOG.md
+++ b/Frends.Oracle.ExecuteProcedure/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.5.0] - 2026-05-26
+
+### Fixed
+
+- Fixed issue where cached connections would fail after Oracle server restart by adding automatic retry logic to detect and recover from stale connections.
+
 ## [2.4.0] - 2026-03-20
 
 ### Fixed

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.Tests/Lib/Helpers.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.Tests/Lib/Helpers.cs
@@ -89,9 +89,9 @@ internal static class Helpers
         using var cmd = con.CreateCommand();
         cmd.CommandType = CommandType.Text;
         cmd.CommandText = @$"
-create or replace procedure test_user.{procedureName} (name in varchar2, address out varchar2) as
+create or replace procedure test_user.{procedureName} (p_name in varchar2, p_address out varchar2) as
 begin
-  select address into address from test_user.workers where name = name;
+  select address into p_address from test_user.workers where name = p_name;
 end {procedureName};";
         cmd.ExecuteNonQuery();
     }

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.Tests/Lib/Helpers.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.Tests/Lib/Helpers.cs
@@ -84,6 +84,18 @@ internal static class Helpers
         }
     }
 
+    internal static void CreateTestProcedure(OracleConnection con, string procedureName = "unitestproc")
+    {
+        using var cmd = con.CreateCommand();
+        cmd.CommandType = CommandType.Text;
+        cmd.CommandText = @$"
+create or replace procedure test_user.{procedureName} (name in varchar2, address out varchar2) as
+begin
+  select address into address from test_user.workers where name = name;
+end {procedureName};";
+        cmd.ExecuteNonQuery();
+    }
+
     internal static void CreateTestUser(OracleConnection con)
     {
         using var cmd = con.CreateCommand();

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.Tests/UnitTests.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.Tests/UnitTests.cs
@@ -772,6 +772,45 @@ end {_proc};";
         };
 
         await Oracle.ExecuteProcedure(_input, output, cleanupOptions, CancellationToken.None);
+    }
 
+    [Test]
+    public async Task ExecuteProcedure_WithInvalidSql_ReturnsErrorWhenThrowErrorOnFailureFalse()
+    {
+        _input.Command = "INVALID SQL SYNTAX HERE";
+        _input.CommandType = OracleCommandType.Command;
+
+        var output = new Output
+        {
+            DataReturnType = OracleCommandReturnType.AffectedRows
+        };
+
+        _options.ThrowErrorOnFailure = false;
+
+        var result = await Oracle.ExecuteProcedure(_input, output, _options, CancellationToken.None);
+
+        ClassicAssert.IsFalse(result.Success);
+        ClassicAssert.IsNotNull(result.Output);
+        ClassicAssert.IsTrue(result.Output.Contains("ORA-"));
+    }
+
+    [Test]
+    public void ExecuteProcedure_WithInvalidSql_ThrowsExceptionWhenThrowErrorOnFailureTrue()
+    {
+        _input.Command = "INVALID SQL SYNTAX HERE";
+        _input.CommandType = OracleCommandType.Command;
+
+        var output = new Output
+        {
+            DataReturnType = OracleCommandReturnType.AffectedRows
+        };
+
+        _options.ThrowErrorOnFailure = true;
+
+        var ex = Assert.ThrowsAsync<Exception>(async () =>
+            await Oracle.ExecuteProcedure(_input, output, _options, CancellationToken.None));
+
+        ClassicAssert.IsNotNull(ex);
+        ClassicAssert.IsTrue(ex.Message.Contains("Error when executing command"));
     }
 }

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.Tests/UnitTests.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.Tests/UnitTests.cs
@@ -699,4 +699,69 @@ end {_proc};";
         await Oracle.ExecuteProcedure(_input, output, _options, CancellationToken.None);
     }
 
+    [Test]
+    public async Task ExecuteProcedure_WithCachedConnection_RecoversAfterOracleRestart()
+    {
+        using var setupCon = new OracleConnection(_connectionStringSys);
+        setupCon.Open();
+        Helpers.CreateTestProcedure(setupCon, _proc);
+        setupCon.Close();
+
+        _input.Command = _proc;
+        _input.CommandType = OracleCommandType.StoredProcedure;
+        _input.Parameters = new[]
+        {
+        new InputParameter
+        {
+            Name = "name",
+            Value = "risto",
+            DataType = ProcedureParameterType.Varchar2,
+            Size = 255
+        }
+    };
+
+        var output = new Output
+        {
+            DataReturnType = OracleCommandReturnType.Parameters,
+            OutputParameters = new[]
+            {
+            new OutputParameter
+            {
+                Name = "address",
+                DataType = ProcedureParameterType.Varchar2,
+                Size = 255
+            }
+        }
+        };
+
+        _options.CloseConnection = false;
+        _options.ClearConnectionPools = false;
+        _options.ThrowErrorOnFailure = true;
+
+        var result1 = await Oracle.ExecuteProcedure(_input, output, _options, CancellationToken.None);
+        ClassicAssert.IsTrue(result1.Success);
+        var dict1 = (Dictionary<string, object>)result1.Output;
+        ClassicAssert.AreEqual("haapatie 9", dict1["address"]);
+
+        // Restart Oracle to invalidate cached connection
+        await oracleContainer.StopAsync();
+        await Task.Delay(3000);
+        await oracleContainer.StartAsync();
+        Helpers.TestConnectionBeforeRunningTests(_connectionStringSys);
+
+        using (var recreateCon = new OracleConnection(_connectionStringSys))
+        {
+            recreateCon.Open();
+            Helpers.CreateTestUser(recreateCon);
+            Helpers.CreateTestTable(recreateCon);
+            Helpers.InsertTestData(recreateCon);
+            Helpers.CreateTestProcedure(recreateCon, _proc);
+            recreateCon.Close();
+        }
+
+        var result2 = await Oracle.ExecuteProcedure(_input, output, _options, CancellationToken.None);
+        ClassicAssert.IsTrue(result2.Success);
+        var dict2 = (Dictionary<string, object>)result2.Output;
+        ClassicAssert.AreEqual("haapatie 9", dict2["address"]);
+    }
 }

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.Tests/UnitTests.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.Tests/UnitTests.cs
@@ -713,7 +713,7 @@ end {_proc};";
         {
         new InputParameter
         {
-            Name = "name",
+            Name = "p_name",
             Value = "risto",
             DataType = ProcedureParameterType.Varchar2,
             Size = 255
@@ -727,7 +727,7 @@ end {_proc};";
             {
             new OutputParameter
             {
-                Name = "address",
+                Name = "p_address",
                 DataType = ProcedureParameterType.Varchar2,
                 Size = 255
             }
@@ -741,7 +741,7 @@ end {_proc};";
         var result1 = await Oracle.ExecuteProcedure(_input, output, _options, CancellationToken.None);
         ClassicAssert.IsTrue(result1.Success);
         var dict1 = (Dictionary<string, object>)result1.Output;
-        ClassicAssert.AreEqual("haapatie 9", dict1["address"]);
+        ClassicAssert.AreEqual("haapatie 9", dict1["p_address"]);
 
         // Restart Oracle to invalidate cached connection
         await oracleContainer.StopAsync();
@@ -762,7 +762,7 @@ end {_proc};";
         var result2 = await Oracle.ExecuteProcedure(_input, output, _options, CancellationToken.None);
         ClassicAssert.IsTrue(result2.Success);
         var dict2 = (Dictionary<string, object>)result2.Output;
-        ClassicAssert.AreEqual("haapatie 9", dict2["address"]);
+        ClassicAssert.AreEqual("haapatie 9", dict2["p_address"]);
 
         var cleanupOptions = new Options
         {

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.Tests/UnitTests.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.Tests/UnitTests.cs
@@ -763,5 +763,15 @@ end {_proc};";
         ClassicAssert.IsTrue(result2.Success);
         var dict2 = (Dictionary<string, object>)result2.Output;
         ClassicAssert.AreEqual("haapatie 9", dict2["address"]);
+
+        var cleanupOptions = new Options
+        {
+            ThrowErrorOnFailure = false,
+            CloseConnection = true,
+            ClearConnectionPools = true
+        };
+
+        await Oracle.ExecuteProcedure(_input, output, cleanupOptions, CancellationToken.None);
+
     }
 }

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Definitions/Options.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Definitions/Options.cs
@@ -48,12 +48,15 @@ public class Options
     public bool CloseConnection { get; set; } = true;
 
     /// <summary>
-    /// Maximum number of retry attempts when encountering stale Oracle connections after server restart.
-    /// Valid values: 1-5. Value of 1 means no retry.
+    /// Number of retry attempts after initial failure when encountering stale Oracle connections.
+    /// Value of 0 means no retry (fail immediately on first error).
+    /// Value of 1 means one retry after initial failure (2 total attempts).
+    /// Used to automatically recover from connection errors after Oracle server restart.
+    /// Valid range: 0-4.
     /// </summary>
-    /// <example>2</example>
-    [DefaultValue(2)]
-    public int ConnectionRetryAttempts { get; set; } = 2;
+    /// <example>1</example>
+    [DefaultValue(1)]
+    public int ConnectionRetryAttempts { get; set; } = 1;
 
     /// <summary>
     /// Delay in milliseconds between connection retry attempts.

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Definitions/Options.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Definitions/Options.cs
@@ -46,4 +46,20 @@ public class Options
     /// <example>true</example>
     [DefaultValue(true)]
     public bool CloseConnection { get; set; } = true;
+
+    /// <summary>
+    /// Maximum number of retry attempts when encountering stale Oracle connections after server restart.
+    /// Valid values: 1-5. Value of 1 means no retry.
+    /// </summary>
+    /// <example>2</example>
+    [DefaultValue(2)]
+    public int ConnectionRetryAttempts { get; set; } = 2;
+
+    /// <summary>
+    /// Delay in milliseconds between connection retry attempts.
+    /// Used when a stale connection is detected after Oracle server restart.
+    /// </summary>
+    /// <example>100</example>
+    [DefaultValue(100)]
+    public int ConnectionRetryDelayMs { get; set; } = 100;
 }

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
@@ -29,7 +29,16 @@ public class Oracle
     public static async Task<Result> ExecuteProcedure([PropertyTab] Input input, [PropertyTab] Output output,
         [PropertyTab] Options options, CancellationToken cancellationToken)
     {
-        const int maxAttempts = 2;
+
+        if (options.ConnectionRetryAttempts < 1 || options.ConnectionRetryAttempts > 5)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options.ConnectionRetryAttempts),
+                "ConnectionRetryAttempts must be in range 1-5.");
+        }
+
+        var maxAttempts = options.ConnectionRetryAttempts;
+
         Exception lastException = null;
 
         for (int attempt = 1; attempt <= maxAttempts; attempt++)
@@ -83,8 +92,7 @@ public class Oracle
             {
                 lastException = ex;
 
-                // Retry once if it's a stale connection error on first attempt
-                if (RetryOnStaleConnection(ex, attempt, maxAttempts, input.ConnectionString))
+                if (await RetryOnStaleConnection(ex, attempt, maxAttempts, input.ConnectionString, options.ConnectionRetryDelayMs, cancellationToken))
                     continue;
 
                 if (options.ThrowErrorOnFailure)
@@ -110,7 +118,7 @@ public class Oracle
             }
         }
 
-        return HandleRetryExhausted(options, lastException);
+        return HandleRetryExhausted(options, lastException, maxAttempts);
     }
 
     private static async Task<OracleConnection> GetOrCreateConnectionAsync(string connectionString, CancellationToken cancellationToken, bool forceNew = false)
@@ -286,12 +294,14 @@ public class Oracle
     }
 
     [ExcludeFromCodeCoverage]
-    private static Result HandleRetryExhausted(Options options, Exception lastException)
+    private static Result HandleRetryExhausted(Options options, Exception lastException, int maxAttempts)
     {
+        var errorMessage = $"Error when executing command after {maxAttempts} attempt(s): {lastException?.Message ?? "Unknown error"}";
+        
         if (options.ThrowErrorOnFailure)
-            throw new ArgumentException("Error when executing command:", lastException?.Message ?? "Unknown error");
+            throw new ArgumentException(errorMessage, lastException);
 
-        return new Result(false, lastException?.Message ?? "Unknown error after retry");
+        return new Result(false, errorMessage);
     }
 
     [ExcludeFromCodeCoverage]
@@ -301,6 +311,22 @@ public class Oracle
         {
             LazyConnectionCache.TryRemove(connectionString, out _);
             OracleConnection.ClearAllPools();
+            return true;
+        }
+        return false;
+    }
+
+    [ExcludeFromCodeCoverage]
+    private static async Task<bool> RetryOnStaleConnection(Exception ex, int attempt, int maxAttempts, string connectionString, int delayMs, CancellationToken cancellationToken)
+    {
+        if (attempt < maxAttempts && IsStaleConnectionException(ex))
+        {
+            LazyConnectionCache.TryRemove(connectionString, out _);
+            OracleConnection.ClearAllPools();
+            
+            if (delayMs > 0)
+                await Task.Delay(delayMs, cancellationToken);
+            
             return true;
         }
         return false;

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
@@ -28,90 +28,155 @@ public class Oracle
     public static async Task<Result> ExecuteProcedure([PropertyTab] Input input, [PropertyTab] Output output,
         [PropertyTab] Options options, CancellationToken cancellationToken)
     {
-        var con = GetLazyConnection(input.ConnectionString);
-        await using var command = new OracleCommand();
+        const int maxAttempts = 2;
+        Exception lastException = null;
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            OracleConnection con = null;
+
+            try
+            {
+                con = await GetOrCreateConnectionAsync(input.ConnectionString, cancellationToken, forceNew: attempt > 1);
+                await using var command = new OracleCommand();
+
+                command.Connection = con;
+                command.CommandText = input.Command;
+                command.CommandTimeout = options.TimeoutSeconds;
+                command.CommandType = (input.CommandType == OracleCommandType.Command)
+                    ? CommandType.Text
+                    : CommandType.StoredProcedure;
+
+                if (input.Parameters != null)
+                    command.Parameters.AddRange(input.Parameters.Select(p => CreateOracleInputParameter(p)).ToArray());
+
+                if (output.OutputParameters != null)
+                    command.Parameters.AddRange(output.OutputParameters.Select(x => CreateOracleOutputParameter(x))
+                        .ToArray());
+
+                command.BindByName = options.BindParameterByName;
+
+                var runCommand = command.ExecuteNonQueryAsync(cancellationToken);
+
+                if (runCommand.IsFaulted)
+                {
+                    if (options.ThrowErrorOnFailure)
+                        throw new Exception(runCommand.Exception.Message);
+
+                    return new Result(runCommand.Exception.Message);
+                }
+
+                var rowsAffected = await runCommand;
+
+                var outputOracleParams = command.Parameters.Cast<OracleParam>()
+                    .Where(p => p.Direction == ParameterDirection.Output);
+
+                var outputDict = outputOracleParams
+                    .ToDictionary(
+                        p => p.ParameterName,
+                        p => GetOracleParameterValue(p)
+                    );
+
+                if (output.DataReturnType == OracleCommandReturnType.AffectedRows)
+                    return new Result(true, rowsAffected);
+                else if (output.DataReturnType == OracleCommandReturnType.Parameters)
+                {
+                    return new Result(true, outputDict);
+                }
+
+                var result = HandleDataset(outputOracleParams, output);
+
+                return new Result(true, result);
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+
+                // Retry once if it's a stale connection error on first attempt
+                if (attempt < maxAttempts && IsStaleConnectionException(ex))
+                {
+                    LazyConnectionCache.TryRemove(input.ConnectionString, out _);
+                    OracleConnection.ClearAllPools();
+                    continue;
+                }
+
+                if (options.ThrowErrorOnFailure)
+                    throw new ArgumentException("Error when executing command:", ex.Message);
+
+                return new Result(false, ex.Message);
+            }
+            finally
+            {
+                if (con != null)
+                {
+                    if (options.CloseConnection)
+                    {
+                        await con.CloseAsync();
+                        con.Dispose();
+                        LazyConnectionCache.TryRemove(input.ConnectionString, out _);
+                    }
+                    if (options.ClearConnectionPools)
+                    {
+                        OracleConnection.ClearAllPools();
+                    }
+                }
+            }
+        }
+
+        if (options.ThrowErrorOnFailure)
+            throw new ArgumentException("Error when executing command:", lastException?.Message ?? "Unknown error");
+
+        return new Result(false, lastException?.Message ?? "Unknown error after retry");
+    }
+
+    private static async Task<OracleConnection> GetOrCreateConnectionAsync(string connectionString, CancellationToken cancellationToken, bool forceNew = false)
+    {
+        if (forceNew)
+        {
+            LazyConnectionCache.TryRemove(connectionString, out _);
+            OracleConnection.ClearAllPools();
+        }
+
+        var con = GetLazyConnection(connectionString);
 
         try
         {
-            try
-            {
+            if (con.State != ConnectionState.Open)
                 await con.OpenAsync(cancellationToken);
-            }
-            catch (Exception e)
-            {
-                //ORA-50005 => Connection already opened
-                if (!e.Message.Contains("ORA-50005")) throw;
-            }
 
-            command.Connection = con;
-            command.CommandText = input.Command;
-            command.CommandTimeout = options.TimeoutSeconds;
-            command.CommandType = (input.CommandType == OracleCommandType.Command)
-                ? CommandType.Text
-                : CommandType.StoredProcedure;
-
-            // Add input parameters to the OracleCommand
-            if (input.Parameters != null)
-                command.Parameters.AddRange(input.Parameters.Select(p => CreateOracleInputParameter(p)).ToArray());
-
-            if (output.OutputParameters != null)
-                command.Parameters.AddRange(output.OutputParameters.Select(x => CreateOracleOutputParameter(x))
-                    .ToArray());
-
-            command.BindByName = options.BindParameterByName;
-
-            var runCommand = command.ExecuteNonQueryAsync(cancellationToken);
-
-            if (runCommand.IsFaulted)
-            {
-                if (options.ThrowErrorOnFailure)
-                    throw new Exception(runCommand.Exception.Message);
-
-                return new Result(runCommand.Exception.Message);
-            }
-
-            var rowsAffected = await runCommand;
-
-            var outputOracleParams = command.Parameters.Cast<OracleParam>()
-                .Where(p => p.Direction == ParameterDirection.Output);
-
-            var outputDict = outputOracleParams
-                .ToDictionary(
-                    p => p.ParameterName,
-                    p => GetOracleParameterValue(p)
-                );
-
-            if (output.DataReturnType == OracleCommandReturnType.AffectedRows)
-                return new Result(true, rowsAffected);
-            else if (output.DataReturnType == OracleCommandReturnType.Parameters)
-            {
-                return new Result(true, outputDict);
-            }
-
-            var result = HandleDataset(outputOracleParams, output);
-
-            return new Result(true, result);
+            return con;
         }
-        catch (Exception ex)
+        catch (OracleException oracleEx) when (oracleEx.Number == 50005)
         {
-            if (options.ThrowErrorOnFailure)
-                throw new ArgumentException("Error when executing command:", ex.Message);
-
-            return new Result(false, ex.Message);
+            // ORA-50005: Connection already opened - OK when caching
+            return con;
         }
-        finally
+        catch (Exception ex) when (IsStaleConnectionException(ex))
         {
-            if (options.CloseConnection)
-            {
-                await con.CloseAsync();
-                con.Dispose();
-                LazyConnectionCache.TryRemove(input.ConnectionString, out _);
-            }
-            if (options.ClearConnectionPools)
-            {
-                OracleConnection.ClearAllPools();
-            }
+            LazyConnectionCache.TryRemove(connectionString, out _);
+            OracleConnection.ClearAllPools();
+            
+            con = GetLazyConnection(connectionString);
+            await con.OpenAsync(cancellationToken);
+            return con;
         }
+    }
+
+    private static bool IsStaleConnectionException(Exception ex)
+    {
+        if (ex is not OracleException oracleEx)
+            return false;
+
+        // Connection lost errors - these indicate server restart or network failure
+        return oracleEx.Number is
+            3113 or  // ORA-03113: end-of-file on communication channel
+            3135 or  // ORA-03135: connection lost contact
+            1089 or  // ORA-01089: immediate shutdown in progress
+            1034 or  // ORA-01034: ORACLE not available
+            12514 or // ORA-12514: TNS:listener does not currently know of service
+            12541 or // ORA-12541: TNS:no listener
+            12537 or // ORA-12537: TNS:connection closed (added for network drops)
+            3114;    // ORA-03114: not connected to ORACLE (added for lost connections)
     }
 
     private static OracleParam CreateOracleInputParameter(InputParameter parameter)

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
@@ -155,7 +155,7 @@ public class Oracle
         {
             LazyConnectionCache.TryRemove(connectionString, out _);
             OracleConnection.ClearAllPools();
-            
+
             con = GetLazyConnection(connectionString);
             await con.OpenAsync(cancellationToken);
             return con;

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
@@ -57,17 +57,7 @@ public class Oracle
 
                 command.BindByName = options.BindParameterByName;
 
-                var runCommand = command.ExecuteNonQueryAsync(cancellationToken);
-
-                if (runCommand.IsFaulted)
-                {
-                    if (options.ThrowErrorOnFailure)
-                        throw new Exception(runCommand.Exception.Message);
-
-                    return new Result(runCommand.Exception.Message);
-                }
-
-                var rowsAffected = await runCommand;
+                var rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken);
 
                 var outputOracleParams = command.Parameters.Cast<OracleParam>()
                     .Where(p => p.Direction == ParameterDirection.Output);

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
@@ -297,7 +297,7 @@ public class Oracle
     private static Result HandleRetryExhausted(Options options, Exception lastException, int maxAttempts)
     {
         var errorMessage = $"Error when executing command after {maxAttempts} attempt(s): {lastException?.Message ?? "Unknown error"}";
-        
+
         if (options.ThrowErrorOnFailure)
             throw new ArgumentException(errorMessage, lastException);
 
@@ -323,10 +323,10 @@ public class Oracle
         {
             LazyConnectionCache.TryRemove(connectionString, out _);
             OracleConnection.ClearAllPools();
-            
+
             if (delayMs > 0)
                 await Task.Delay(delayMs, cancellationToken);
-            
+
             return true;
         }
         return false;

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
@@ -29,16 +29,14 @@ public class Oracle
     public static async Task<Result> ExecuteProcedure([PropertyTab] Input input, [PropertyTab] Output output,
         [PropertyTab] Options options, CancellationToken cancellationToken)
     {
-
-        if (options.ConnectionRetryAttempts < 1 || options.ConnectionRetryAttempts > 5)
+        if (options.ConnectionRetryAttempts < 0 || options.ConnectionRetryAttempts > 4)
         {
             throw new ArgumentOutOfRangeException(
                 nameof(options.ConnectionRetryAttempts),
-                "ConnectionRetryAttempts must be in range 1-5.");
+                "ConnectionRetryAttempts must be in range 0-4.");
         }
 
-        var maxAttempts = options.ConnectionRetryAttempts;
-
+        var maxAttempts = 1 + options.ConnectionRetryAttempts;
         Exception lastException = null;
 
         for (int attempt = 1; attempt <= maxAttempts; attempt++)

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Concurrent;
-using Oracle.ManagedDataAccess.Client;
-using OracleParam = Oracle.ManagedDataAccess.Client.OracleParameter;
-using System.ComponentModel;
-using Frends.Oracle.ExecuteProcedure.Definitions;
-using System.Data;
-using System.Xml.Linq;
+﻿using Frends.Oracle.ExecuteProcedure.Definitions;
 using Newtonsoft.Json;
+using Oracle.ManagedDataAccess.Client;
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Data;
+using System.Diagnostics.CodeAnalysis;
+using System.Xml.Linq;
+using OracleParam = Oracle.ManagedDataAccess.Client.OracleParameter;
 
 namespace Frends.Oracle.ExecuteProcedure;
 
@@ -101,7 +102,7 @@ public class Oracle
                 }
 
                 if (options.ThrowErrorOnFailure)
-                    throw new ArgumentException("Error when executing command:", ex.Message);
+                    throw new Exception($"Error when executing command: {ex.Message}", ex);
 
                 return new Result(false, ex.Message);
             }
@@ -162,6 +163,7 @@ public class Oracle
         }
     }
 
+    [ExcludeFromCodeCoverage]
     private static bool IsStaleConnectionException(Exception ex)
     {
         if (ex is not OracleException oracleEx)

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
@@ -147,12 +147,7 @@ public class Oracle
         }
         catch (Exception ex) when (IsStaleConnectionException(ex))
         {
-            LazyConnectionCache.TryRemove(connectionString, out _);
-            OracleConnection.ClearAllPools();
-
-            con = GetLazyConnection(connectionString);
-            await con.OpenAsync(cancellationToken);
-            return con;
+            return await CreateFreshConnection(connectionString, cancellationToken);
         }
     }
 
@@ -319,6 +314,17 @@ public class Oracle
             return true;
         }
         return false;
+    }
+
+    [ExcludeFromCodeCoverage]
+    private static async Task<OracleConnection> CreateFreshConnection(string connectionString, CancellationToken cancellationToken)
+    {
+        LazyConnectionCache.TryRemove(connectionString, out _);
+        OracleConnection.ClearAllPools();
+
+        var con = GetLazyConnection(connectionString);
+        await con.OpenAsync(cancellationToken);
+        return con;
     }
 
 }

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.cs
@@ -94,12 +94,8 @@ public class Oracle
                 lastException = ex;
 
                 // Retry once if it's a stale connection error on first attempt
-                if (attempt < maxAttempts && IsStaleConnectionException(ex))
-                {
-                    LazyConnectionCache.TryRemove(input.ConnectionString, out _);
-                    OracleConnection.ClearAllPools();
+                if (RetryOnStaleConnection(ex, attempt, maxAttempts, input.ConnectionString))
                     continue;
-                }
 
                 if (options.ThrowErrorOnFailure)
                     throw new Exception($"Error when executing command: {ex.Message}", ex);
@@ -124,10 +120,7 @@ public class Oracle
             }
         }
 
-        if (options.ThrowErrorOnFailure)
-            throw new ArgumentException("Error when executing command:", lastException?.Message ?? "Unknown error");
-
-        return new Result(false, lastException?.Message ?? "Unknown error after retry");
+        return HandleRetryExhausted(options, lastException);
     }
 
     private static async Task<OracleConnection> GetOrCreateConnectionAsync(string connectionString, CancellationToken cancellationToken, bool forceNew = false)
@@ -305,6 +298,27 @@ public class Oracle
         });
 
         return con.Value;
+    }
+
+    [ExcludeFromCodeCoverage]
+    private static Result HandleRetryExhausted(Options options, Exception lastException)
+    {
+        if (options.ThrowErrorOnFailure)
+            throw new ArgumentException("Error when executing command:", lastException?.Message ?? "Unknown error");
+
+        return new Result(false, lastException?.Message ?? "Unknown error after retry");
+    }
+
+    [ExcludeFromCodeCoverage]
+    private static bool RetryOnStaleConnection(Exception ex, int attempt, int maxAttempts, string connectionString)
+    {
+        if (attempt < maxAttempts && IsStaleConnectionException(ex))
+        {
+            LazyConnectionCache.TryRemove(connectionString, out _);
+            OracleConnection.ClearAllPools();
+            return true;
+        }
+        return false;
     }
 
 }

--- a/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.csproj
+++ b/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure/Frends.Oracle.ExecuteProcedure.csproj
@@ -7,7 +7,7 @@
 		<AssemblyName>Frends.Oracle.ExecuteProcedure</AssemblyName>
 		<RootNamespace>Frends.Oracle.ExecuteProcedure</RootNamespace>
 
-		<Version>2.4.0</Version>
+		<Version>2.5.0</Version>
 		<Authors>Frends</Authors>
 		<Copyright>Frends</Copyright>
 		<Company>Frends</Company>


### PR DESCRIPTION
Please review my changes :)

## Review Checklist

- [ ] Task version updated (x.x.0)
- [ ] CHANGELOG.md updated
- [ ] Solution builds
- [ ] Warnings resolved (if possible)
- [ ] Typos resolved
- [ ] Tests cover new code
- [ ] Description how to run tests locally added to README.md (if needed)
- [ ] All tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable automatic retry for recovering stale Oracle connections (retry attempts and retry delay).
* **Bug Fixes**
  * Procedure execution now automatically retries and recovers from stale cached Oracle connections after an Oracle server restart.
* **Tests**
  * Added integration and unit tests covering cached-connection recovery and invalid-SQL behaviors.
* **Documentation**
  * Changelog updated and package version bumped to 2.5.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FrendsPlatform/Frends.Oracle/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->